### PR TITLE
Add basic CRM service with Kanban tasks and ad analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# n8n
+# CRM Service
+
+Simple CRM service for marketers with Kanban tasks per client and ad analytics.
+
+## Running
+
+```
+node server.js
+```
+
+## Testing
+
+```
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "n8n",
+  "version": "1.0.0",
+  "description": "Simple CRM service for marketers with Kanban tasks and ad analytics",
+  "main": "server.js",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,93 @@
+import http from 'node:http';
+import { URL } from 'node:url';
+
+export function createServer() {
+  const clients = [];
+  const tasks = [];
+  const ads = [];
+  let nextClientId = 1;
+  let nextTaskId = 1;
+
+  const server = http.createServer(async (req, res) => {
+    const parsedUrl = new URL(req.url, `http://${req.headers.host}`);
+
+    // Helper to send JSON responses
+    const sendJson = (status, data) => {
+      res.writeHead(status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data));
+    };
+
+    const body = await getBody(req);
+
+    if (req.method === 'POST' && parsedUrl.pathname === '/clients') {
+      const client = { id: nextClientId++, name: body.name };
+      clients.push(client);
+      return sendJson(201, client);
+    }
+
+    const clientTaskMatch = parsedUrl.pathname.match(/^\/clients\/(\d+)(?:\/tasks(?:\/(\d+))?)?$/);
+    if (clientTaskMatch) {
+      const clientId = Number(clientTaskMatch[1]);
+
+      if (clientTaskMatch[2]) {
+        // specific task not implemented
+      }
+
+      if (parsedUrl.pathname.endsWith('/tasks')) {
+        if (req.method === 'POST') {
+          const task = { id: nextTaskId++, clientId, title: body.title, status: body.status || 'todo' };
+          tasks.push(task);
+          return sendJson(201, task);
+        }
+        if (req.method === 'GET') {
+          const clientTasks = tasks.filter(t => t.clientId === clientId);
+          return sendJson(200, clientTasks);
+        }
+      } else if (req.method === 'GET') {
+        const client = clients.find(c => c.id === clientId);
+        if (client) return sendJson(200, client);
+      }
+    }
+
+    if (req.method === 'POST' && parsedUrl.pathname === '/ads') {
+      ads.push({ clientId: body.clientId, impressions: body.impressions || 0, clicks: body.clicks || 0 });
+      return sendJson(201, { ok: true });
+    }
+
+    if (req.method === 'GET' && parsedUrl.pathname === '/analytics/ads') {
+      const result = {};
+      for (const ad of ads) {
+        if (!result[ad.clientId]) result[ad.clientId] = { impressions: 0, clicks: 0 };
+        result[ad.clientId].impressions += ad.impressions;
+        result[ad.clientId].clicks += ad.clicks;
+      }
+      return sendJson(200, result);
+    }
+
+    res.writeHead(404);
+    res.end('Not Found');
+  });
+
+  return server;
+}
+
+function getBody(req) {
+  return new Promise(resolve => {
+    let data = '';
+    req.on('data', chunk => { data += chunk; });
+    req.on('end', () => {
+      try {
+        resolve(data ? JSON.parse(data) : {});
+      } catch {
+        resolve({});
+      }
+    });
+  });
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const port = process.env.PORT || 3000;
+  createServer().listen(port, () => {
+    console.log(`Server running on port ${port}`);
+  });
+}

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { createServer } from '../server.js';
+
+test('create client, task, and collect ad analytics', async (t) => {
+  const server = createServer().listen(0);
+  t.after(() => server.close());
+  const base = `http://localhost:${server.address().port}`;
+
+  // Create client
+  let res = await fetch(base + '/clients', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: 'Acme Corp' })
+  });
+  assert.equal(res.status, 201);
+  const client = await res.json();
+  assert.equal(client.name, 'Acme Corp');
+
+  // Create task for client
+  res = await fetch(`${base}/clients/${client.id}/tasks`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title: 'Launch campaign' })
+  });
+  assert.equal(res.status, 201);
+  const task = await res.json();
+  assert.equal(task.status, 'todo');
+
+  // Add ad metrics
+  res = await fetch(base + '/ads', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ clientId: client.id, impressions: 1000, clicks: 50 })
+  });
+  assert.equal(res.status, 201);
+
+  // Get analytics
+  res = await fetch(base + '/analytics/ads');
+  assert.equal(res.status, 200);
+  const analytics = await res.json();
+  assert.deepStrictEqual(analytics[client.id], { impressions: 1000, clicks: 50 });
+});


### PR DESCRIPTION
## Summary
- implement minimal Node.js CRM server tracking clients, Kanban-style tasks, and ad metrics
- document usage and provide built-in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68951aca59a48328b5cd8fe58d993a68